### PR TITLE
Revert "Fix test_gather_meta_design: Missing 'name' dependency and host-dependent paths"

### DIFF
--- a/pinjected/helper_structure.py
+++ b/pinjected/helper_structure.py
@@ -77,23 +77,7 @@ class MetaContext:
             design = EmptyDesign
         overrides = await r.provide_or('overrides', EmptyDesign)
 
-        # Start with user default design
-        base_design = load_user_default_design()
-        
-        # Apply accumulated design first to establish base bindings
-        base_design = base_design + acc
-        
-        # Apply default_design_paths only for keys not in accumulated design
-        if StrBindKey('default_design_paths') in acc:
-            for key in design.keys():
-                if key not in acc:
-                    base_design = base_design + instances(**{str(key): design[key]})
-        
-        # Apply overrides from accumulated design last to ensure highest precedence
-        if StrBindKey('overrides') in acc:
-            base_design = base_design + overrides
-            
-        return base_design + load_user_overrides_design()
+        return load_user_default_design() + design + overrides + load_user_overrides_design()
 
     @staticmethod
     def load_default_design_for_variable(var: ModuleVarPath | str):

--- a/test/test_module_inspector.py
+++ b/test/test_module_inspector.py
@@ -35,14 +35,14 @@ def test_get_project_root(tmp_path):
 
 
 def test_walk_module_attr():
-    test_file = Path(__file__).parent.parent / "pinjected/test_package/child/module1.py"
+    test_file = "/Users/s22625/repos/pinject-design/pinjected/test_package/child/module1.py"
     items = []
-    for item in walk_module_attr(test_file, "__meta_design__"):
+    for item in walk_module_attr(Path(test_file), "__meta_design__"):
         items.append(item)
     pprint(items)
 
 
 def test_gather_meta_design():
-    test_file = Path(__file__).parent.parent / "pinjected/test_package/child/module1.py"
-    mc: MetaContext = MetaContext.gather_from_path(test_file)
-    assert mc.final_design.provide('name') == "test_package.child.module1"
+    test_file = "/Users/s22625/repos/pinject-design/pinjected/test_package/child/module1.py"
+    mc: MetaContext = MetaContext.gather_from_path(Path(test_file))
+    mc.final_design.provide('name') == "test_package.child.module1"


### PR DESCRIPTION
Reverts proboscis/pinjected#63