### PR TITLE
Add tests for DesignSpec protocol

### DIFF
--- a/TODOs.md
+++ b/TODOs.md
@@ -1,5 +1,5 @@
 
-# migrate gathering method to new one so that we can use __design__ 
+# migrate gathering method to new one so that we can use __design__ -> done
 # gather DesignSpec from __design__ 
 # update ml-nexus to provide DesignSpec
 # fix ml-nexus-mlplatform to work with new DesignSpec

--- a/pinjected/__init__.py
+++ b/pinjected/__init__.py
@@ -1,3 +1,5 @@
+from pinjected.di.design_spec.impl import SimpleBindSpec
+from pinjected.di.design_spec.protocols import DesignSpec
 from pinjected.di.injected import Injected
 from pinjected.di.decorators import injected_function, injected_instance, injected, instance, reload, register
 from pinjected.di.util import EmptyDesign, instances, providers, classes, destructors, design
@@ -22,6 +24,8 @@ __all__ = [
     "IProxy",
     "design",
     "register",
-    "AsyncResolver"
+    "AsyncResolver",
+    "DesignSpec",
+    "SimpleBindSpec"
 ]
 

--- a/pinjected/di/design_spec/impl.py
+++ b/pinjected/di/design_spec/impl.py
@@ -37,11 +37,11 @@ class MergedDesignSpec(DesignSpec):
     def get_spec(self, key: IBindKey) -> Maybe[BindSpec]:
         """
         Search for a key in all source specs in order.
-        Returns the first matching spec found, or Nothing if no spec is found.
+        Returns the first matching spec found from reverse order, or Nothing if no spec is found.
         
-        This means that earlier specs in the srcs list take precedence over later ones.
+        This means that last specs in the srcs list take precedence over first ones.
         """
-        for src in self.srcs:
+        for src in reversed(self.srcs):
             spec = src.get_spec(key)
             if spec is not Nothing:
                 return spec
@@ -106,11 +106,11 @@ class SimpleBindSpec(BindSpec[T]):
             return Nothing
         return Some(lambda key: FutureResult.from_value(self._documentation))
 
+
 """
 Now, we need a way to accumulate specs from repo, so that RunContext can use it to provide better guidance.
 
 """
-
 
 if __name__ == '__main__':
     from loguru import logger

--- a/pinjected/di/design_spec/protocols.py
+++ b/pinjected/di/design_spec/protocols.py
@@ -29,10 +29,39 @@ class BindSpec(Protocol[T]):
 
 @runtime_checkable
 class DesignSpec(Protocol):
+    """
+    A specification of bindings that provides validation and documentation.
+    
+    When adding specs together with the + operator, the right-hand spec takes precedence.
+    This means if both specs have bindings for the same key, the binding from the
+    right-hand side (the one being added) will be used.
+    
+    Example:
+        spec1 + spec2  # spec2 takes precedence for any overlapping keys
+    """
     def __add__(self, other: "DesignSpec") -> "DesignSpec":
+        """
+        Combine two design specs, with the right-hand side (other) taking precedence.
+        If both specs define bindings for the same key, the binding from 'other' will be used.
+        
+        Args:
+            other: The spec to add, which will override this spec for duplicate keys
+            
+        Returns:
+            A new DesignSpec combining both specs with the right-hand side having precedence
+        """
         pass
 
     def get_spec(self, key: IBindKey) -> Maybe[BindSpec]:
+        """
+        Get the binding specification for a given key.
+        
+        Args:
+            key: The binding key to look up
+            
+        Returns:
+            Maybe[BindSpec]: Just(spec) if the key is found, Nothing otherwise
+        """
         pass
 
     @staticmethod

--- a/pinjected/di/design_spec/protocols.py
+++ b/pinjected/di/design_spec/protocols.py
@@ -1,4 +1,4 @@
-from typing import Protocol, TypeVar, Callable
+from typing import Protocol, TypeVar, Callable, runtime_checkable
 
 from returns.future import FutureResultE
 from returns.maybe import Maybe
@@ -27,7 +27,7 @@ class BindSpec(Protocol[T]):
     """
     spec_doc_provider: Maybe[SpecDocProviderType]
 
-
+@runtime_checkable
 class DesignSpec(Protocol):
     def __add__(self, other: "DesignSpec") -> "DesignSpec":
         pass

--- a/pinjected/helper_structure.py
+++ b/pinjected/helper_structure.py
@@ -5,9 +5,9 @@ from beartype import beartype
 from pinjected.di.design_spec.protocols import DesignSpec
 from pinjected.pinjected_logging import logger
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Union, Any
 
-from pinjected import Design, Injected, design, EmptyDesign
+from pinjected import Design, Injected, design, EmptyDesign, DelegatedVar
 from pinjected.module_helper import walk_module_attr, walk_module_with_special_files
 from pinjected.module_inspector import ModuleVarSpec
 from pinjected.module_var_path import load_variable_by_module_path, ModuleVarPath
@@ -29,19 +29,40 @@ class IdeaRunConfigurations:
     configs: Dict[str, List[IdeaRunConfiguration]]
 
 
-def gather_design_spec(file_path) -> DesignSpec:
-    acc = DesignSpec.empty()
-    for var in walk_module_with_special_files(file_path, attr_names=["__spec__"],
-                                              special_filenames=["__init__.py", "__pinjected__.py"]):
-        spec: DesignSpec = var.var
-        acc += spec
-    return acc
+async def _a_resolve(tgt: Union[Any, DelegatedVar, Injected]):
+    if isinstance(tgt, (DelegatedVar, Injected)):
+        resolver = AsyncResolver(EmptyDesign)
+        return await resolver.provide(tgt)
+    return tgt
+
+
+@dataclass
+class SpecTrace:
+    trace: List[ModuleVarSpec[DesignSpec]]
+    accumulated: DesignSpec
+
+    @staticmethod
+    async def a_gather_from_path(file_path: Path):
+        trace = []
+        acc = DesignSpec.empty()
+        for var in walk_module_with_special_files(file_path, attr_names=["__design_spec__"],
+                                                  special_filenames=["__init__.py", "__pinjected__.py"]):
+            trace.append(var)
+            assert var.var is not None
+            spec: DesignSpec = await _a_resolve(var.var)
+            assert isinstance(spec, DesignSpec),f"Expected DesignSpec, got {type(spec)}"
+            acc += spec
+        return SpecTrace(
+            trace=trace,
+            accumulated=acc
+        )
 
 
 @dataclass
 class MetaContext:
     trace: List[ModuleVarSpec[Design]]
     accumulated: Design
+    spec_trace: SpecTrace
 
     @staticmethod
     async def a_gather_from_path(file_path: Path, meta_design_name: str = "__meta_design__"):
@@ -51,7 +72,7 @@ class MetaContext:
            
         iterate through modules, for __pinjected__.py and __init__.py, looking at __meta_design__.
         but now we should look for
-        __spec__ for DesignSpec,
+        __design_spec__ for DesignSpec,
         __design__ for Design,
         The order is __init__.py -> __pinjected__.py -> target_file.py
         """
@@ -91,7 +112,11 @@ class MetaContext:
             res = res + design(overrides=overrides)
             return MetaContext(
                 trace=designs,
-                accumulated=res
+                accumulated=res,
+                spec_trace=SpecTrace(
+                    trace=[],
+                    accumulated=DesignSpec.empty()
+                )
             )
 
     @staticmethod
@@ -109,13 +134,13 @@ class MetaContext:
             trace.append(var)
             ovr = EmptyDesign
             if var.var_path.endswith("__meta_design__"):
-                ovr = var.var
+                ovr = await _a_resolve(var.var)
                 if StrBindKey("overrides") in var.var:
                     logger.debug(
                         f"Now `overrides` are merged with `__meta_design__`. __meta_design__ and `overrides` is deprecated. use __design__ instead.")
                     ovr += await AsyncResolver(var.var).provide("overrides")
             elif var.var_path.endswith("__design__"):
-                ovr = var.var
+                ovr = await _a_resolve(var.var)
             for k, bind in ovr.bindings.items():
                 key_to_path[k] = var.var_path
             acc += ovr
@@ -123,9 +148,12 @@ class MetaContext:
         for k, v in key_to_path.items():
             logger.debug(f"Override Key {k} from {v}")
 
+        spec = await SpecTrace.a_gather_from_path(file_path)
+
         return MetaContext(
             trace=trace,
-            accumulated=acc
+            accumulated=acc,
+            spec_trace=spec
         )
 
     @staticmethod
@@ -167,7 +195,7 @@ class MetaContext:
         meta_context = await MetaContext.a_gather_bindings_with_legacy(var.module_file_path)
         design = await meta_context.a_final_design
         return design
-        
+
     @staticmethod
     def load_default_design_for_variable(var: ModuleVarPath | str):
         """

--- a/pinjected/helper_structure.py
+++ b/pinjected/helper_structure.py
@@ -43,15 +43,36 @@ class SpecTrace:
 
     @staticmethod
     async def a_gather_from_path(file_path: Path):
+        """
+        Gather DesignSpec instances from a module path hierarchy.
+        This method should NOT look in __init__.py files, only in __pinjected__.py files.
+        """
         trace = []
-        acc = DesignSpec.empty()
-        for var in walk_module_with_special_files(file_path, attr_names=["__design_spec__"],
-                                                  special_filenames=["__init__.py", "__pinjected__.py"]):
+        # Initialize with empty implementation
+        from pinjected.di.design_spec.impl import DesignSpecImpl
+        acc = DesignSpecImpl({})  # Start with an empty spec
+        logger.debug(f"Gathering DesignSpec from path: {file_path}")
+        
+        # Collect specs from the specified path, using only __pinjected__.py files
+        special_files = list(walk_module_with_special_files(file_path, 
+                                                         attr_names=["__design_spec__"],
+                                                         special_filenames=["__pinjected__.py"]))
+        
+        # Process in reverse order to ensure child directories take precedence
+        special_files.reverse()
+        
+        # Load and merge all specs
+        for var in special_files:
             trace.append(var)
+            logger.debug(f"Found __design_spec__ in {var.var_path}")
             assert var.var is not None
             spec: DesignSpec = await _a_resolve(var.var)
-            assert isinstance(spec, DesignSpec),f"Expected DesignSpec, got {type(spec)}"
-            acc += spec
+            assert isinstance(spec, DesignSpec), f"Expected DesignSpec, got {type(spec)}"
+            
+            # Add to the accumulation
+            acc = spec + acc  # Ensure new spec takes precedence over accumulated specs
+        
+        # Return the trace and accumulated design spec
         return SpecTrace(
             trace=trace,
             accumulated=acc

--- a/test/test_design_spec.py
+++ b/test/test_design_spec.py
@@ -1,0 +1,235 @@
+from pathlib import Path
+
+import pytest
+from returns.maybe import Nothing
+
+from pinjected import DesignSpec, SimpleBindSpec
+from pinjected.helper_structure import SpecTrace, MetaContext
+from pinjected.v2.keys import StrBindKey
+
+
+@pytest.mark.asyncio
+async def test_design_spec_empty():
+    """Test that empty DesignSpec behaves correctly."""
+    empty_spec = DesignSpec.empty()
+    assert empty_spec.get_spec(StrBindKey("any_key")) is Nothing
+
+
+@pytest.mark.asyncio
+async def test_design_spec_get_spec():
+    """Test that DesignSpec can retrieve specifications for keys."""
+    # Create a DesignSpec with a known binding
+    test_spec = DesignSpec.new(
+        test_key=SimpleBindSpec(
+            validator=lambda item: "test_key must be int" if not isinstance(item, int) else None,
+            documentation="This is a test key"
+        )
+    )
+    
+    # Test that we can retrieve the spec
+    spec = test_spec.get_spec(StrBindKey("test_key"))
+    assert spec is not Nothing, "Should find the spec for test_key"
+    
+    # Test that non-existent keys return Nothing
+    assert test_spec.get_spec(StrBindKey("non_existent")) is Nothing
+
+
+@pytest.mark.asyncio
+async def test_design_spec_addition():
+    """Test that DesignSpec addition combines specs correctly."""
+    # Create two specs with different keys
+    spec1 = DesignSpec.new(
+        key1=SimpleBindSpec(documentation="Spec 1")
+    )
+    
+    spec2 = DesignSpec.new(
+        key2=SimpleBindSpec(documentation="Spec 2")
+    )
+    
+    # Combine them
+    combined = spec1 + spec2
+    
+    # Test that both keys are accessible
+    assert combined.get_spec(StrBindKey("key1")) is not Nothing
+    assert combined.get_spec(StrBindKey("key2")) is not Nothing
+    
+    # Test that specs are retrieved from the correct source
+    key1_spec = combined.get_spec(StrBindKey("key1")).unwrap()
+    key2_spec = combined.get_spec(StrBindKey("key2")).unwrap()
+    
+    assert key1_spec.spec_doc_provider is not Nothing
+    assert key2_spec.spec_doc_provider is not Nothing
+    
+    # When resolved, they should provide the correct documentation
+    key1_doc_provider = key1_spec.spec_doc_provider.unwrap()
+    key2_doc_provider = key2_spec.spec_doc_provider.unwrap()
+    
+    key1_doc = await key1_doc_provider(StrBindKey("key1"))
+    key2_doc = await key2_doc_provider(StrBindKey("key2"))
+    
+    # The result is a FutureResult[IOSuccess[str]], so we need to use .unwrap() to get the IO and then to check its value
+    from returns.unsafe import unsafe_perform_io
+    assert unsafe_perform_io(key1_doc.unwrap()) == "Spec 1"
+    assert unsafe_perform_io(key2_doc.unwrap()) == "Spec 2"
+
+
+@pytest.mark.asyncio
+async def test_design_spec_precedence():
+    """Test that when specs are combined, the leftmost one takes precedence for duplicate keys."""
+    # Create two specs with the same key but different validators and documentation
+    spec1 = DesignSpec.new(
+        shared_key=SimpleBindSpec(
+            validator=lambda item: "must be int" if not isinstance(item, int) else None,
+            documentation="Spec 1 documentation"
+        )
+    )
+    
+    spec2 = DesignSpec.new(
+        shared_key=SimpleBindSpec(
+            validator=lambda item: "must be str" if not isinstance(item, str) else None,
+            documentation="Spec 2 documentation"
+        )
+    )
+    
+    # Combine them with spec1 taking precedence
+    combined = spec1 + spec2
+    
+    # The shared_key should have spec1's validator and documentation
+    shared_key_spec = combined.get_spec(StrBindKey("shared_key"))
+    assert shared_key_spec is not Nothing
+    
+    # Unwrap the Some[BindSpec] to get the actual BindSpec
+    shared_key_bind_spec = shared_key_spec.unwrap()
+    
+    # Check that the documentation is from spec1
+    doc_provider = shared_key_bind_spec.spec_doc_provider.unwrap()
+    doc = await doc_provider(StrBindKey("shared_key"))
+    from returns.unsafe import unsafe_perform_io
+    assert unsafe_perform_io(doc.unwrap()) == "Spec 1 documentation"
+    
+    # For validator testing, we'll need to create a test SimpleBindSpec and check the validator
+    # Verifying that the validator property is from spec1 
+    # (In this case we can only verify that the validator exists, not its exact behavior)
+    assert shared_key_bind_spec.validator is not Nothing
+
+
+@pytest.mark.asyncio
+async def test_a_gather_design_spec_from_path():
+    """Test that SpecTrace.a_gather_from_path collects __design_spec__ attributes."""
+    # Path to the test file with __design_spec__
+    test_file = Path(__file__).parent / "test_package/__pinjected__.py"
+    
+    # Gather the specs
+    spec_trace = await SpecTrace.a_gather_from_path(test_file)
+    accumulated_spec = spec_trace.accumulated
+    
+    # Verify that we found at least one spec
+    assert len(spec_trace.trace) > 0, "Should find at least one __design_spec__"
+    
+    # Print the trace for debugging
+    print(f"Found {len(spec_trace.trace)} __design_spec__ attributes")
+    for i, var in enumerate(spec_trace.trace):
+        print(f"  {i}. {var.var_path}")
+    
+    # Verify that the design_name key has a spec
+    design_name_spec = accumulated_spec.get_spec(StrBindKey("design_name"))
+    assert design_name_spec is not Nothing, "Should find a spec for design_name"
+    
+    # Unwrap the Some[BindSpec] to get the actual BindSpec
+    design_name_bind_spec = design_name_spec.unwrap()
+    
+    # Test the validator - it should validate that design_name is a string
+    assert design_name_bind_spec.validator is not Nothing
+    
+    # Check the documentation
+    doc_provider = design_name_bind_spec.spec_doc_provider.unwrap()
+    doc = await doc_provider(StrBindKey("design_name"))
+    from returns.unsafe import unsafe_perform_io
+    assert unsafe_perform_io(doc.unwrap()) == "This is a test design spec"
+
+
+@pytest.mark.asyncio
+async def test_meta_context_includes_design_spec():
+    """Test that MetaContext.a_gather_bindings_with_legacy also gathers design specs."""
+    # Path to the test file
+    test_file = Path(__file__).parent / "test_package/__pinjected__.py"
+    
+    # Gather designs and specs
+    mc = await MetaContext.a_gather_bindings_with_legacy(test_file)
+    
+    # Verify that spec_trace is populated
+    assert mc.spec_trace is not None
+    assert len(mc.spec_trace.trace) > 0, "Should find at least one __design_spec__"
+    
+    # Verify that we can access the accumulated spec
+    accumulated_spec = mc.spec_trace.accumulated
+    assert accumulated_spec.get_spec(StrBindKey("design_name")) is not Nothing
+    
+    # Print the spec trace for debugging
+    print(f"Found {len(mc.spec_trace.trace)} specs in MetaContext")
+    for i, var in enumerate(mc.spec_trace.trace):
+        print(f"  {i}. {var.var_path}")
+
+
+@pytest.mark.asyncio
+async def test_multi_level_design_spec_hierarchy():
+    """Test that design specs are properly collected from a hierarchy of modules."""
+    # Path to a module in the child directory
+    test_file = Path(__file__).parent / "test_package/child/module1.py"
+    
+    # For this test we need to get specs from each location manually
+    import sys
+    from pinjected.module_helper import walk_module_with_special_files
+    from pinjected.module_var_path import ModuleVarPath
+    
+    # Verify that we find specs from both levels
+    specs_found = []
+    
+    for var in walk_module_with_special_files(test_file, attr_names=["__design_spec__"],
+                                              special_filenames=["__pinjected__.py"]):
+        specs_found.append(var.var_path)
+    
+    # Print the specs found
+    print(f"Found design specs: {specs_found}")
+    
+    # Check that we found specs from both levels
+    found_top_level = any('test_package.__pinjected__' in spec_path for spec_path in specs_found)
+    found_child_level = any('test_package.child.__pinjected__' in spec_path for spec_path in specs_found)
+    
+    assert found_top_level, "Should find __design_spec__ from top level"
+    assert found_child_level, "Should find __design_spec__ from child level"
+    
+    # Directly load and test the specs
+    from pinjected.v2.keys import StrBindKey
+    
+    # Load the top-level spec
+    from test.test_package.__pinjected__ import __design_spec__ as top_spec
+    # Load the child-level spec
+    from test.test_package.child.__pinjected__ import __design_spec__ as child_spec
+    
+    # Test that we can get specs from both levels
+    design_name_spec = top_spec.get_spec(StrBindKey("design_name"))
+    assert design_name_spec is not Nothing, "Should find spec for design_name from top level"
+    
+    design_var_spec = child_spec.get_spec(StrBindKey("design_var"))
+    assert design_var_spec is not Nothing, "Should find spec for design_var from child level"
+    
+    # Manually create a merged spec to test precedence
+    merged_spec = child_spec + top_spec  # Child takes precedence
+    
+    # Verify that shared keys use the child's value
+    shared_key_spec = merged_spec.get_spec(StrBindKey("shared_key"))
+    assert shared_key_spec is not Nothing, "Should find spec for shared_key"
+    
+    # Check some properties of the specs
+    design_name_bind_spec = design_name_spec.unwrap()
+    assert design_name_bind_spec.validator is not Nothing
+    
+    design_var_bind_spec = design_var_spec.unwrap()
+    assert design_var_bind_spec.validator is not Nothing
+    
+    # Check documentation
+    from returns.unsafe import unsafe_perform_io
+    doc_provider = design_var_bind_spec.spec_doc_provider.unwrap()
+    doc = await doc_provider(StrBindKey("design_var"))
+    assert "Child module" in unsafe_perform_io(doc.unwrap()), "Should have documentation from child directory"

--- a/test/test_package/__pinjected__.py
+++ b/test/test_package/__pinjected__.py
@@ -1,6 +1,6 @@
 # Test special file at the top level
 
-from pinjected import design
+from pinjected import design, DesignSpec, SimpleBindSpec
 
 __meta_design__ = design(
     special_var="from_top_level_pinjected_file",
@@ -11,6 +11,14 @@ __design__ = design(
     design_name="test_package.__pinjected__",
     design_var="from_top_level_design"
 )
+
+__design_spec__ = DesignSpec.new(
+    design_name=SimpleBindSpec(
+        validator = lambda item: "design_name must be str" if not isinstance(item, str) else None,
+        documentation="This is a test design spec"
+    )
+)
+
 
 special_config = {
     'source': '__pinjected__',

--- a/test/test_package/child/__pinjected__.py
+++ b/test/test_package/child/__pinjected__.py
@@ -1,4 +1,4 @@
-from pinjected import design
+from pinjected import design, DesignSpec, SimpleBindSpec
 
 __meta_design__ = design(
     name="test_package.child.__pinjected__",
@@ -11,6 +11,17 @@ __design__ = design(
     design_name="test_package.child.__pinjected__",
     design_var="from_design_in_pinjected_file",
     shared_key="from_design"  # This should override the value from __meta_design__
+)
+
+__design_spec__ = DesignSpec.new(
+    design_var=SimpleBindSpec(
+        validator=lambda item: "design_var must be str" if not isinstance(item, str) else None,
+        documentation="Child module design variable"
+    ),
+    shared_key=SimpleBindSpec(
+        validator=lambda item: "shared_key must be str" if not isinstance(item, str) else None,
+        documentation="A key shared between __meta_design__ and __design__"
+    )
 )
 
 special_config = {


### PR DESCRIPTION
## Summary
- Add tests for DesignSpec protocol and implementation
- Tests cover empty specs, spec retrieval, validation, documentation, and addition operations
- Verify multi-level hierarchy properly gathers and merges specs
- Update SpecTrace implementation to properly handle design specs
- Add __design_spec__ to test files for validation

## Test plan
- Run test/test_design_spec.py to verify all test cases pass
- Confirm that specs from different module levels correctly combine with proper precedence

🤖 Generated with [Claude Code](https://claude.ai/code)