### PR TITLE
Add design spec validation to AsyncResolver

### DIFF
--- a/pinjected/run_helpers/run_injected.py
+++ b/pinjected/run_helpers/run_injected.py
@@ -252,6 +252,7 @@ class RunContext:
             resolver = AsyncResolver(
                 dd,
                 callbacks=[self.provision_callback] if self.provision_callback else [],
+                spec=self.src_meta_context.spec_trace.accumulated
             )
             _res = await resolver.provide(tgt)
 


### PR DESCRIPTION
## Summary
- Pass accumulated design specifications to AsyncResolver in RunContext
- Enable runtime validation of bindings against specifications defined in module hierarchy
- Leverage the recently implemented DesignSpec system for runtime validation

## Test plan
- Existing tests continue to pass
- Design specs defined in module hierarchy will now be used for validation during dependency resolution

🤖 Generated with [Claude Code](https://claude.ai/code)