### PR TITLE
Fix missing OpenAI organization provider

### DIFF
--- a/packages/openai_support/src/pinjected_openai/clients.py
+++ b/packages/openai_support/src/pinjected_openai/clients.py
@@ -15,6 +15,14 @@ def openai_api_key() -> str:
     from loguru import logger
 
     logger.warning(f"using openai api key from environment variable")
-    api_key = os.environ.get("OPENAI_API_KEY", None)
-    # assert api_key is not None, "OPENAI_API_KEY environment variable must be set, or openai_api_key must be set via pinjected injection."
-    return ""
+    api_key = os.environ.get("OPENAI_API_KEY")
+    assert api_key is not None, (
+        "OPENAI_API_KEY environment variable must be set or openai_api_key must be injected."
+    )
+    return api_key
+
+
+@instance
+def openai_organization() -> str | None:
+    """Retrieve the OpenAI organization identifier if present."""
+    return os.environ.get("OPENAI_ORGANIZATION")


### PR DESCRIPTION
## Summary
- fix `openai_api_key` to return the environment variable value
- add `openai_organization` provider

## Testing
- `ruff check packages/openai_support/src/pinjected_openai/clients.py`