### PR TITLE
Fix PINJ044 documentation to align with stricter enforcement

### DIFF
--- a/packages/pinjected-linter/docs/rules/pinj044_no_async_resolver_creation.md
+++ b/packages/pinjected-linter/docs/rules/pinj044_no_async_resolver_creation.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-Direct instantiation of `AsyncResolver` is not recommended. Use the CLI approach (`python -m pinjected run`) for running pinjected applications instead.
+Direct instantiation of `AsyncResolver` is not allowed. Use the CLI approach (`python -m pinjected run`) for running pinjected applications instead.
 
 ## Rationale
 
-Direct usage of `AsyncResolver` is discouraged because:
+Direct usage of `AsyncResolver` is not allowed because:
 
 1. **Configuration Flexibility**: CLI execution allows easy parameter overrides without code changes
 2. **Code Volume**: Direct usage increases boilerplate code

--- a/packages/pinjected-linter/rust-poc/src/rules/pinj044_no_async_resolver_creation.rs
+++ b/packages/pinjected-linter/rust-poc/src/rules/pinj044_no_async_resolver_creation.rs
@@ -1,7 +1,7 @@
-//! PINJ044: Direct AsyncResolver creation not recommended
+//! PINJ044: Direct AsyncResolver creation not allowed
 //!
-//! Direct instantiation of AsyncResolver is not recommended. While it can be used in __main__ blocks
-//! for script execution, the CLI approach is the preferred method for running pinjected applications.
+//! Direct instantiation of AsyncResolver is not allowed. The CLI approach (`python -m pinjected run`)
+//! is the required method for running pinjected applications.
 
 use crate::models::{RuleContext, Severity, Violation};
 use crate::rules::base::LintRule;
@@ -303,7 +303,7 @@ result = await resolver.provide("value")
         let violations = check_code(code, "test_app.py");
         assert_eq!(violations.len(), 1);
         assert_eq!(violations[0].rule_id, "PINJ044");
-        assert!(violations[0].message.contains("should not be instantiated directly"));
+        assert!(violations[0].message.contains("not allowed"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Update PINJ044 documentation to state AsyncResolver is "not allowed" instead of "not recommended"
- Fix Rust implementation module docs and test assertions to match
- Ensure consistency between documentation and error messages

## Context
Following up on PR #118, this aligns the PINJ044 rule with the stricter enforcement policy where AsyncResolver usage is an error unless explicitly marked with special comments.

## Changes
- Changed "not recommended" → "not allowed" in documentation
- Updated Rust module documentation to match
- Fixed test assertion to check for "not allowed" message

🤖 Generated with [Claude Code](https://claude.ai/code)